### PR TITLE
Update en.lua

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -5,8 +5,8 @@ Locales ['en'] = {
   ['weed_processprompt'] = 'press ~INPUT_CONTEXT~ to start ~g~Process Cannabis~s~.',
   ['weed_processingstarted'] = 'processing ~g~Cannabis~s~ into ~g~Marijuana~s~...',
   ['weed_processingfull'] = 'processing ~r~canceled~s~ due to full inventory!',
-  ['weed_processingenough'] = 'you must have ~b2x~s~ ~g~Cannabis~s~ in order to process.',
-  ['weed_processed'] = 'you\'ve processed ~b~2x~s~ ~g~Cannabis~s~ to ~b~1x~s~ ~g~Marijuana~s~',
+  ['weed_processingenough'] = 'you must have ~b~3x~s~ ~g~Cannabis~s~ in order to process.',
+  ['weed_processed'] = 'you\'ve processed ~b~3x~s~ ~g~Cannabis~s~ to ~b~1x~s~ ~g~Marijuana~s~',
   ['weed_processingtoofar'] = 'the processing has been ~r~canceled~s~ due to you abandoning the area.',
   
   -- meth


### PR DESCRIPTION
Modified en.lua to correct format for Weed. Script requires 3 Cannabis to process. Locale only specified 2 and had a missing character for the color code.